### PR TITLE
Introduce HasVal typeclass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ servant-test.cabal
 *.o
 *.prof
 *.db
+.idea
+out/
+*.iml

--- a/src/Common/HasVal/Class.hs
+++ b/src/Common/HasVal/Class.hs
@@ -4,5 +4,5 @@ module Common.HasVal.Class where
 
 import GHC.TypeLits
 
-class HasVal (k :: Symbol) t env where
+class HasVal (k :: Symbol) t env | k env -> t where
   getVal :: env -> t

--- a/src/Common/HasVal/Class.hs
+++ b/src/Common/HasVal/Class.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
+module Common.HasVal.Class where
+
+import GHC.TypeLits
+
+class HasVal (k :: Symbol) t env where
+  getVal :: env -> t

--- a/src/Common/Version/Class.hs
+++ b/src/Common/Version/Class.hs
@@ -1,15 +1,23 @@
 module Common.Version.Class
   ( HasVal (..)
   , Version
+  , toText
+  , fromText
   ) where
 
 import qualified Data.Text as T
 import Common.HasVal.Class
 
-type Version = T.Text
+newtype Version = Version { toText :: T.Text } deriving (Eq, Show)
+
+fromText :: T.Text -> Version
+fromText = Version
 
 instance HasVal "version" Version T.Text where
-  getVal = id
+  getVal = Version
 
 instance HasVal "version" Version String where
-  getVal = T.pack
+  getVal = Version . T.pack
+
+instance HasVal "version" Version Version where
+  getVal = id

--- a/src/Common/Version/Class.hs
+++ b/src/Common/Version/Class.hs
@@ -1,14 +1,15 @@
 module Common.Version.Class
-  ( HasVersion(..)
+  ( HasVal (..)
+  , Version
   ) where
 
 import qualified Data.Text as T
+import Common.HasVal.Class
 
-class HasVersion a where
-  getVersion :: a -> T.Text
+type Version = T.Text
 
-instance HasVersion String where
-  getVersion = T.pack
+instance HasVal "version" Version T.Text where
+  getVal = id
 
-instance HasVersion T.Text where
-  getVersion = id
+instance HasVal "version" Version String where
+  getVal = T.pack

--- a/src/Common/Version/Server.hs
+++ b/src/Common/Version/Server.hs
@@ -5,25 +5,25 @@ module Common.Version.Server
   , server
   , API
   , ServerConstraints
-  , HasVersion(..)
+  , HasVal (..)
+  , Version
   ) where
 
 import Control.Monad.Reader
 import Data.Proxy
 import Servant
 import Data.Aeson.TH
-import qualified Data.Text as T
-import Common.Version.Class ( HasVersion(..) )
+import Common.Version.Class ( HasVal(..), Version )
 
-newtype Version = Version { version :: T.Text } deriving (Eq, Show)
-$(deriveJSON defaultOptions ''Version)
+newtype WireVersion = WireVersion { version :: Version } deriving (Eq, Show)
+$(deriveJSON defaultOptions ''WireVersion)
 
-type API = Get '[JSON] Version
+type API = Get '[JSON] WireVersion
 
 api :: Proxy API
 api = Proxy
 
-type ServerConstraints m a = (HasVersion a, MonadReader a m)
+type ServerConstraints m a = (HasVal "version" Version a, MonadReader a m)
 
 server :: ServerConstraints m a => ServerT API m
-server = asks $ Version . getVersion
+server = asks $ WireVersion . getVal @"version"

--- a/src/Common/Version/Server.hs
+++ b/src/Common/Version/Server.hs
@@ -9,14 +9,16 @@ module Common.Version.Server
   , Version
   ) where
 
+import GHC.Generics
 import Control.Monad.Reader
 import Data.Proxy
 import Servant
-import Data.Aeson.TH
-import Common.Version.Class ( HasVal(..), Version )
+import Data.Aeson
+import Common.Version.Class ( HasVal(..), Version, toText )
 
-newtype WireVersion = WireVersion { version :: Version } deriving (Eq, Show)
-$(deriveJSON defaultOptions ''WireVersion)
+newtype WireVersion = WireVersion { version :: Version } deriving (Eq, Show, Generic)
+instance ToJSON WireVersion where
+  toJSON (WireVersion v) = object [("version", String $ toText v)]
 
 type API = Get '[JSON] WireVersion
 

--- a/src/ServantTest/Config.hs
+++ b/src/ServantTest/Config.hs
@@ -19,11 +19,8 @@ data Config = Config { port :: Port
                      }
   deriving (Eq, Show)
 
-class HasConfig p where
-  getConfig :: p -> Config
-
-instance HasConfig Config where
-  getConfig = id
+instance HasVal "config" Config Config where
+  getVal = id
 
 instance HasVal "version" Version Config where
   getVal = fromText . version
@@ -35,10 +32,10 @@ type API = CS.API Config
 api :: Proxy API
 api = Proxy
 
-type ServerConstraints m c = (HasConfig c, CS.ServerConstraints m c)
+type ServerConstraints m c = (HasVal "config" Config c, CS.ServerConstraints m c)
 
 server :: ServerConstraints m c => ServerT API m
-server = asks getConfig
+server = asks $ getVal @"config"
 
 loadConfig :: IO Config
 loadConfig = CL.loadConfig

--- a/src/ServantTest/Config.hs
+++ b/src/ServantTest/Config.hs
@@ -11,7 +11,7 @@ import qualified Data.Text as T
 
 import qualified Common.Config.Server as CS
 import qualified Common.Config.Loader as CL
-import Common.Version.Class (HasVersion(..))
+import Common.Version.Class (HasVal(..), Version)
 
 data Config = Config { port :: Port
                      , version :: T.Text
@@ -25,8 +25,8 @@ class HasConfig p where
 instance HasConfig Config where
   getConfig = id
 
-instance HasVersion Config where
-  getVersion = version
+instance HasVal "version" Version Config where
+  getVal = version
 
 $(deriveJSON defaultOptions ''Config)
 

--- a/src/ServantTest/Config.hs
+++ b/src/ServantTest/Config.hs
@@ -11,7 +11,7 @@ import qualified Data.Text as T
 
 import qualified Common.Config.Server as CS
 import qualified Common.Config.Loader as CL
-import Common.Version.Class (HasVal(..), Version)
+import Common.Version.Class (HasVal(..), Version, fromText)
 
 data Config = Config { port :: Port
                      , version :: T.Text
@@ -26,7 +26,7 @@ instance HasConfig Config where
   getConfig = id
 
 instance HasVal "version" Version Config where
-  getVal = version
+  getVal = fromText . version
 
 $(deriveJSON defaultOptions ''Config)
 

--- a/src/ServantTest/Controllers/User.hs
+++ b/src/ServantTest/Controllers/User.hs
@@ -2,8 +2,9 @@ module ServantTest.Controllers.User where
 
 import Prelude hiding (id)
 import Data.List (sortOn)
+import Common.HasVal.Class
 import ServantTest.Models.User (User(..), NewUser(..))
-import ServantTest.Db.Transactor (Transactor(..), HasTransactor(..))
+import ServantTest.Db.Transactor (Transactor(..))
 import ServantTest.Db.User as Db.User
 
 sortOnAge :: [User] -> [User]
@@ -12,25 +13,25 @@ sortOnAge = sortOn userAge
 sortOnName :: [User] -> [User]
 sortOnName = sortOn userName
 
-type ControllerConstraints env t m stmt = (HasTransactor env t, Transactor t m stmt, UserDb stmt)
+type ControllerConstraints env t m stmt = (HasVal "transactor" t env, Transactor t m stmt, UserDb stmt)
 
-listUsers :: ControllerConstraints env t m stmt => ([User] -> [User]) -> env -> m [User]
+listUsers :: forall env t m stmt. ControllerConstraints env t m stmt => ([User] -> [User]) -> env -> m [User]
 listUsers listTransform env = do
-  let transactor = getTransactor env
+  let transactor = getVal @"transactor" env
   allUsers <- transact transactor Db.User.listUsers
   return $ listTransform allUsers
 
 getUser :: ControllerConstraints env t m stmt => Integer -> env -> m (Maybe User)
 getUser idParam env = do
-  let transactor = getTransactor env
+  let transactor = getVal @"transactor" env
   transact transactor $ Db.User.getUser idParam
 
 createUser :: ControllerConstraints env t m stmt => NewUser -> env -> m User
 createUser newUser env = do
-  let transactor = getTransactor env
+  let transactor = getVal @"transactor" env
   transact transactor $ Db.User.createUser newUser
 
 deleteUser :: ControllerConstraints env t m stmt => Integer -> env -> m (Maybe User)
 deleteUser idParam env = do
-  let transactor = getTransactor env
+  let transactor = getVal @"transactor" env
   transact transactor $ Db.User.deleteUser idParam

--- a/src/ServantTest/Db/Transactor.hs
+++ b/src/ServantTest/Db/Transactor.hs
@@ -2,6 +2,3 @@ module ServantTest.Db.Transactor where
 
 class Monad transactionM => Transactor t transactionM action | t -> action where
   transact :: t -> action a -> transactionM a
-
-class HasTransactor p t | p -> t where
-  getTransactor :: p -> t

--- a/src/ServantTest/Env.hs
+++ b/src/ServantTest/Env.hs
@@ -2,7 +2,7 @@ module ServantTest.Env where
 
 import Common.Version.Class (HasVal(..), Version)
 import ServantTest.Config (Config(..))
-import ServantTest.Db.Transactor (Transactor (..), HasTransactor (..))
+import ServantTest.Db.Transactor (Transactor (..))
 import ServantTest.Db.SQLite (SqliteDb, sqliteDb)
 import qualified ServantTest.Db.User as Db.User
 
@@ -11,8 +11,8 @@ data Env = Env {
 , sqlite :: SqliteDb
 }
 
-instance HasTransactor Env SqliteDb where
-  getTransactor = sqlite
+instance HasVal "transactor" SqliteDb Env where
+  getVal = sqlite
 
 instance HasVal "version" Version Env where
   getVal = getVal @"version" . config

--- a/src/ServantTest/Env.hs
+++ b/src/ServantTest/Env.hs
@@ -1,6 +1,6 @@
 module ServantTest.Env where
 
-import Common.Version.Class (HasVersion(..))
+import Common.Version.Class (HasVal(..), Version)
 import ServantTest.Config (Config(..), HasConfig(..))
 import ServantTest.Db.Transactor (Transactor (..), HasTransactor (..))
 import ServantTest.Db.SQLite (SqliteDb, sqliteDb)
@@ -14,8 +14,8 @@ data Env = Env {
 instance HasTransactor Env SqliteDb where
   getTransactor = sqlite
 
-instance HasVersion Env where
-  getVersion = getVersion . config
+instance HasVal "version" Version Env where
+  getVal = getVal @"version" . config
 
 instance HasConfig Env where
   getConfig = config

--- a/src/ServantTest/Env.hs
+++ b/src/ServantTest/Env.hs
@@ -1,7 +1,7 @@
 module ServantTest.Env where
 
 import Common.Version.Class (HasVal(..), Version)
-import ServantTest.Config (Config(..), HasConfig(..))
+import ServantTest.Config (Config(..))
 import ServantTest.Db.Transactor (Transactor (..), HasTransactor (..))
 import ServantTest.Db.SQLite (SqliteDb, sqliteDb)
 import qualified ServantTest.Db.User as Db.User
@@ -17,8 +17,8 @@ instance HasTransactor Env SqliteDb where
 instance HasVal "version" Version Env where
   getVal = getVal @"version" . config
 
-instance HasConfig Env where
-  getConfig = config
+instance HasVal "config" Config Env where
+  getVal = config
 
 buildEnv :: Config -> IO Env
 buildEnv config = do

--- a/test/ServantTest/HttpApi/UserSpec.hs
+++ b/test/ServantTest/HttpApi/UserSpec.hs
@@ -10,7 +10,8 @@ import Control.Monad.Reader
 
 import qualified ServantTest.Env as Env
 import qualified ServantTest.Config as Config
-import ServantTest.Db.Transactor (Transactor(..), HasTransactor(..))
+import Common.HasVal.Class
+import ServantTest.Db.Transactor (Transactor(..))
 import qualified ServantTest.Db.User as Db.User
 import ServantTest.Models.User
 import ServantTest.HttpApi.User (api, server)
@@ -20,7 +21,7 @@ dbfile = ".tempdbs_usertest.db"
 
 prepareDb :: Env.Env -> IO ()
 prepareDb env = do
-    let t = getTransactor env
+    let t = getVal @"transactor" env
     transact t $ do
       users <- Db.User.listUsers
       mapM_ (Db.User.deleteUser . userId) users

--- a/test/ServantTest/Test/Helpers.hs
+++ b/test/ServantTest/Test/Helpers.hs
@@ -1,7 +1,8 @@
 module ServantTest.Test.Helpers where
 
 import Control.Monad.Writer
-import ServantTest.Db.Transactor (Transactor(..), HasTransactor(..))
+import Common.HasVal.Class
+import ServantTest.Db.Transactor (Transactor(..))
 
 data MockDb action = MockDb
 
@@ -13,8 +14,8 @@ instance Transactor (MockDb action) (TestM action) (DbActions action) where
   transact :: MockDb action -> DbActions action a -> TestM action a
   transact _ (DbActions actions result) = tell [actions] >> return result
 
-instance HasTransactor (MockDb action) (MockDb action) where
-  getTransactor = id
+instance HasVal "transactor" (MockDb action) (MockDb action) where
+  getVal = id
 
 runTest :: Writer w a -> (a, w)
 runTest = runWriter


### PR DESCRIPTION
Used `HasVal/getVal` because the `Has/get` had a name collisions with Test.Hspec.Wai.

Closes #1 